### PR TITLE
Update referee.py

### DIFF
--- a/verification/referee.py
+++ b/verification/referee.py
@@ -3,7 +3,7 @@ from checkio import api
 from checkio.referees.io import CheckiOReferee
 from checkio.referees import cover_codes
 from tests import TESTS
-from collections import defaultdict
+from collections import defaultdict, Counter
 
 
 def checker(inputs, user_answer):
@@ -24,7 +24,7 @@ def checker(inputs, user_answer):
             powers.append(answer[1])
         else:
             return False, (user_answer, 'Fail')
-    if cities - all_cities or sorted(plants) != sorted(powers):
+    if cities - all_cities or Counter(powers) - Counter(plants):
         return False, (user_answer, 'Fail')
 
     # power supply check


### PR DESCRIPTION
The user should be able to propose a solution using less power plants than the given ones.
Meaning that `powers` should be a sublist of `plants`. The easiest way to check that is comparing list's counters.
Then eventually, we can later propose random tests with more than the minimal number of power plants, since it seems complicated to me.