### PR TITLE
Change IO types according to Veky

### DIFF
--- a/editor/initial_code/python_3
+++ b/editor/initial_code/python_3
@@ -4,9 +4,9 @@ def power_plants(network, ranges):
 
 
 if __name__ == '__main__':
-    assert sorted(power_plants([['A', 'B'], ['B', 'C']], [1])) == [('B', 1)]
-    assert sorted(power_plants([['A', 'B'], ['B', 'C'], ['C', 'D'], ['D', 'E']], [2])) == [('C', 2)]
-    assert sorted(power_plants([['A', 'B'], ['B', 'C'], ['C', 'D'], ['D', 'E'], ['E', 'F']], [1, 1])) == [('B', 1), ('E', 1)]
-    assert sorted(power_plants([['A', 'B'], ['B', 'C'], ['A', 'D'], ['B', 'E']], [1, 0])) == [('B', 1), ('D', 0)]
+    assert power_plants({('A', 'B'), ('B', 'C')}, [1]) == {'B': 1}
+    assert power_plants({('A', 'B'), ('B', 'C'), ('C', 'D'), ('D', 'E')}, [2]) == {'C': 2}
+    assert power_plants({('A', 'B'), ('B', 'C'), ('C', 'D'), ('D', 'E'), ('E', 'F')}, [1, 1]) == {'B': 1, 'E': 1}
+    assert power_plants({('A', 'B'), ('B', 'C'), ('A', 'D'), ('B', 'E')}, [1, 0]) == {'B': 1, 'D': 0}
 
     print('The local tests are done. Click on "Check" for more real tests.')

--- a/editor/initial_code/python_3
+++ b/editor/initial_code/python_3
@@ -1,6 +1,7 @@
-def power_plants(network, ranges):
+from typing import Set, Tuple, List, Dict
 
-    return []
+def power_plants(network: Set[Tuple[str, str]], ranges: List[int]) -> Dict[str, int]:
+    return {}
 
 
 if __name__ == '__main__':

--- a/info/task_description.html
+++ b/info/task_description.html
@@ -9,7 +9,7 @@
 <p>
 The intercity network and the range of each power plant are given as input values.
 A power plant can provide power to placed city and within its range.
-You have to return a list (or iterable) of tuple that the city where you will place the power plant and its range.
+You have to return a dictionary: the key is the city where you will place the power plant and the value is its range.
 
 </p>
 
@@ -21,9 +21,9 @@ You have to return a list (or iterable) of tuple that the city where you will pl
         <strong>Example:</strong>
     </p>
 <!-- Do NOT change the indentation of this pre-block -->
-<pre class="brush: python">sorted(power_plants([['A', 'B'], ['B', 'C'], ['C', 'D'], ['D', 'E']], [2])) == [('C', 2)]
-sorted(power_plants([['A', 'B'], ['B', 'C'], ['C', 'D'], ['D', 'E'], ['E', 'F']], [1, 1])) == [('B', 1), ('E', 1)]
-sorted(power_plants([['A', 'B'], ['B', 'C'], ['A', 'D'], ['B', 'E']], [1, 0])) == [('B', 1), ('D', 0)]
+<pre class="brush: python">power_plants({('A', 'B'), ('B', 'C'), ('C', 'D'), ('D', 'E')}, [2]) == {'C': 2}
+power_plants({('A', 'B'), ('B', 'C'), ('C', 'D'), ('D', 'E'), ('E', 'F')}, [1, 1]) == {'B': 1, 'E': 1}
+power_plants({('A', 'B'), ('B', 'C'), ('A', 'D'), ('B', 'E')}, [1, 0]) == {'B': 1, 'D': 0}
 </pre>
 <!-- pre-block end -->
     <p style="text-align: center;"><img src="{{MEDIA}}example.png" style="max-height: 294px"></p>
@@ -33,7 +33,7 @@ sorted(power_plants([['A', 'B'], ['B', 'C'], ['A', 'D'], ['B', 'E']], [1, 0])) =
     <strong>Input: </strong>
     <p>
     <ul>
-        <li>The first: The intercity network, represented as a list of connections. Each connection is a list of two nodes that are connected.</li>
+        <li>The first: The intercity network, represented as a set of connections. Each connection is a tuple of two nodes that are connected.</li>
         <li>The second: The range of each power plant, represented as a list of integer.</li>
     </ul>
 </p>
@@ -41,7 +41,7 @@ sorted(power_plants([['A', 'B'], ['B', 'C'], ['A', 'D'], ['B', 'E']], [1, 0])) =
 <p>
     <strong>Output: </strong>
     <ul>
-    <li>a list (or iterable) of placement, Each placement is a tuple of city where you will place the power plant and its range.</li>
+    <li>A dictionary of placements, each key is the city where you will place the power plant and each value is the corresponding range.</li>
 </ul>
 </p>
 

--- a/verification/referee.py
+++ b/verification/referee.py
@@ -41,9 +41,13 @@ def checker(inputs, user_answer):
     return not all_cities - powered_cities, (user_answer, 'Success')
 
 
-cover_iterable = '''
+cover = '''
 def cover(func, args):
-    return list(func(*args))
+    network, ranges = args
+    network = set(map(tuple, network))
+    res = func(network, ranges)
+    assert isinstance(res, dict)
+    return list(res.items())
 '''
 
 api.add_listener(
@@ -56,7 +60,7 @@ api.add_listener(
             "js": "powerPlants"
         },
         cover_code={
-            'python-3': cover_iterable,
+            'python-3': cover,
             'js-node': cover_codes.js_unwrap_args
         }
     ).on_ready)


### PR DESCRIPTION
I totally agree with Veky Input / Output types, and since you seemed to agree too, here I am with the needed changes.

We probably could do it in a different way (by changing test's output into dicts and change the checker) but change the cover is a simple fix.
`network` is a set of tuples, `ranges` remains a list and the user must now return a dictionary like `{'A': 1, 'E': 2}`.

I updated task description and initial code, and I added types to the user function.
I hope I didn't make any mistake.